### PR TITLE
Fix slade formula for macOS Catalina

### DIFF
--- a/slade.rb
+++ b/slade.rb
@@ -8,8 +8,7 @@ class Slade < Formula
   head "https://github.com/sirjuddington/SLADE.git"
 
   # SFML newer than 2.1 requires OS X 10.7
-  # Although, it's not excplicitly declared in its formula at the moment
-  depends_on :macos => :lion  
+  # This is fine, because brew only supports the last 2 macOS versions, and we're on 10.15 atm
 
   depends_on "cmake"
   depends_on "fluid-synth"

--- a/slade.rb
+++ b/slade.rb
@@ -15,6 +15,7 @@ class Slade < Formula
   depends_on "freeimage"
   depends_on "ftgl"
   depends_on "sfml"
+  depends_on "GLEW"
 
   #
   # NOTE: Cannot use default wxWidgets formula at the moment
@@ -25,7 +26,7 @@ class Slade < Formula
   depends_on "wxwidgets-slade"
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", "-DGLEW_INCLUDE_PATH=/usr/local/Cellar/glew/2.1.0/include", "-DGLEW_LIBRARY=/usr/local/Cellar/glew/2.1.0/lib/libGLEW.2.1.dylib", ".", *std_cmake_args
     system "make"
     prefix.install "SLADE.app"
   end


### PR DESCRIPTION
Removed some deprecated brew syntax and added a dependency of the newer SLADE versions.

Note: The formula is hard-coded to expect brew to install GLEW 2.1.0, but a new version of GLEW hasn't been released since 2017.